### PR TITLE
Fixes issue #12

### DIFF
--- a/DurandalAuth.Web/App/services/appsecurity.js
+++ b/DurandalAuth.Web/App/services/appsecurity.js
@@ -443,7 +443,7 @@ define(["durandal/system","durandal/app","plugins/router","services/routeconfig"
 						.fail(function () {
 							dfd.resolve(true);
 						});
-				} else {
+				} else if (sessionStorage["accessToken"] || localStorage["accessToken"]) {
 					self.getUserInfo()
 						.done(function (data) {
 							if (data.userName) {
@@ -454,6 +454,8 @@ define(["durandal/system","durandal/app","plugins/router","services/routeconfig"
 						.fail(function () {
 							dfd.resolve(true);
 						});
+				} else {
+					dfd.resolve(true);
 				}				
 			}).promise();
 		}


### PR DESCRIPTION
If there is no access token available, don't bother trying to get the user info since it will fail anyway and will cause a login prompt on Windows Phone devices.
