### PR TITLE
services/appsecurity referenced twice

### DIFF
--- a/DurandalAuth.Web/App/viewmodels/shell.js
+++ b/DurandalAuth.Web/App/viewmodels/shell.js
@@ -1,5 +1,5 @@
-﻿define(['plugins/router', 'services/appsecurity', 'services/errorhandler', 'services/entitymanagerprovider', 'model/modelBuilder', 'services/appsecurity'],
-    function (router, appsecurity, errorhandler, entitymanagerprovider, modelBuilder, appsecurity) {
+﻿define(['plugins/router', 'services/appsecurity', 'services/errorhandler', 'services/entitymanagerprovider', 'model/modelBuilder'],
+    function (router, appsecurity, errorhandler, entitymanagerprovider, modelBuilder) {
 
     entitymanagerprovider.modelBuilder = modelBuilder.extendMetadata;
 


### PR DESCRIPTION
As mentioned in #25, the appsecurity module is referenced twice.

This change removes one of them.